### PR TITLE
Added error handling support and cleaned up some code

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -32,3 +32,7 @@
 - **What you contributed:** *Minor Webviewer Features*
 
 ---
+
+- **Name/Username:** *MoordMachineYT*
+- **Contact/Social Media:** *@MoordMachineYT#1910 on Discord*
+- **What you contributed:** *Possibility to handle errors instead of logging them*

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -35,4 +35,4 @@
 
 - **Name/Username:** *MoordMachineYT*
 - **Contact/Social Media:** *@MoordMachineYT#1910 on Discord*
-- **What you contributed:** *Possibility to handle errors instead of logging them*
+- **What you contributed:** *Support for handling errors*

--- a/src/functions/add.js
+++ b/src/functions/add.js
@@ -1,17 +1,16 @@
 const util = require('util'),
   _ = require('lodash/object');
 
-module.exports = function(ID, data, options, db, webview) {
+module.exports = function(ID, data, options = {}, db, webview) {
   const getInfo = new Promise((resolve, error) => {
 
     if (typeof data !== 'number') return console.log('Error: .add() data is not a number.');
 
     // Configure Options
-    if (!options) options = {};
     options = {
       target: options.target || undefined,
       table: options.table || 'json'
-    }
+    };
 
     let response;
 
@@ -49,9 +48,9 @@ module.exports = function(ID, data, options, db, webview) {
               input = JSON.stringify(input);
               db.prepare(`UPDATE ${options.table} SET json = (?) WHERE ID = (?)`).run(input, ID);
 
-            } else console.log(`Error: Target for .add(${ID}, ${data}) is not a number.`);
+            } else error(new TypeError(`Target for .add(${ID}, ${data}) is not a number.`));
 
-          } else console.log(`Error: Target for .add(${ID}, ${data}) is not a number.`);
+          } else error(new TypeError(`Error: Target for .add(${ID}, ${data}) is not a number.`));
 
         }
 
@@ -78,4 +77,4 @@ module.exports = function(ID, data, options, db, webview) {
 
   });
   return getInfo;
-}
+};

--- a/src/functions/delete.js
+++ b/src/functions/delete.js
@@ -1,11 +1,10 @@
-module.exports = function(ID, options, db) {
+module.exports = function(ID, options = {}, db) {
   const getInfo = new Promise((resolve, error) => {
 
     // Configure Options
-    if (!options) options = {};
     options = {
       table: options.table || 'json'
-    }
+    };
 
     let response;
 
@@ -28,4 +27,4 @@ module.exports = function(ID, options, db) {
 
   });
   return getInfo;
-}
+};

--- a/src/functions/fetch.js
+++ b/src/functions/fetch.js
@@ -1,15 +1,14 @@
 const util = require('util'),
   _ = require('lodash/object');
 
-module.exports = function(ID, options, db) {
+module.exports = function(ID, options = {}, db) {
   const getInfo = new Promise((resolve) => {
 
     // Configure Options
-    if (!options) options = {};
     options = {
       target: options.target || undefined,
       table: options.table || 'json'
-    }
+    };
 
     let response;
 
@@ -49,4 +48,4 @@ module.exports = function(ID, options, db) {
 
   });
   return getInfo;
-}
+};

--- a/src/functions/fetchAll.js
+++ b/src/functions/fetchAll.js
@@ -1,12 +1,11 @@
-module.exports = function(options, db) {
+module.exports = function(options = {}, db) {
   const getInfo = new Promise((resolve, error) => {
 
     let response = [];
     
-    if (!options) options = {};
     options = {
       table: options.table || 'json'
-    }
+    };
 
     function createDb() {
       db.prepare(`CREATE TABLE IF NOT EXISTS ${options.table} (ID TEXT, json TEXT)`).run();
@@ -15,14 +14,14 @@ module.exports = function(options, db) {
 
     function fetchAll() {
       let resp = db.prepare(`SELECT * FROM ${options.table}`).all();
-      resp.forEach(function(entry) {
+      for (var entry of resp) {
         if (entry.ID === null) return;
         if (entry.ID === 'WEBVIEW_ACTIVE_SOCKETS') return;
         response.push({
           ID: entry.ID,
           data: JSON.parse(entry.json)
-        })
-      })
+        });
+      }
       returnDb();
     }
 
@@ -34,4 +33,4 @@ module.exports = function(options, db) {
 
   });
   return getInfo;
-}
+};

--- a/src/functions/push.js
+++ b/src/functions/push.js
@@ -1,21 +1,20 @@
 const util = require('util'),
   _ = require('lodash/object');
 
-module.exports = function(ID, data, options, db) {
+module.exports = function(ID, data, options = {}, db) {
   const getInfo = new Promise((resolve, error) => {
 
     // Configure Options
-    if (!options) options = {};
     options = {
       target: options.target || undefined,
       table: options.table || 'json'
-    }
+    };
 
     let response;
 
     function createDb() {
       db.prepare(`CREATE TABLE IF NOT EXISTS ${options.table} (ID TEXT, json TEXT)`).run();
-      checkIfCreated(false)
+      checkIfCreated(false);
     }
 
     function checkIfCreated(updated) {
@@ -44,6 +43,7 @@ module.exports = function(ID, data, options, db) {
 
           } catch (e) {
             response = `Unable to push, may not be pushing to an array. \nError: ${e.message}`;
+            error(new Error(response));
             returnDb();
           }
         } else {
@@ -84,4 +84,4 @@ module.exports = function(ID, data, options, db) {
 
   });
   return getInfo;
-}
+};

--- a/src/functions/set.js
+++ b/src/functions/set.js
@@ -1,15 +1,14 @@
 const util = require('util'),
   _ = require('lodash/object');
 
-module.exports = function(ID, data, options, db) {
+module.exports = function(ID, data, options = {}, db) {
   const getInfo = new Promise((resolve, error) => {
 
     // Configure Options
-    if (!options) options = {};
     options = {
       target: options.target || undefined,
       table: options.table || 'json'
-    }
+    };
 
     // Define Variables
     let response,
@@ -20,11 +19,11 @@ module.exports = function(ID, data, options, db) {
       util.inspect(data);
       input = JSON.stringify(data);
     } catch (e) {
-      return console.log(`Please supply a valid input @ ID: ${ID}\nError: ${e.message}`);
+      return error(new TypeError(`Please supply a valid input @ ID: ${ID}\nError: ${e.message}`));
     }
 
     // Check if setting undefined
-    if (typeof data === 'undefined') return console.log(`Input cannot be undefined @ ID: ${ID}`);
+    if (typeof data === 'undefined') return error(new TypeError(`Input cannot be undefined @ ID: ${ID}`));
 
     // Statements
     function newConnection() {
@@ -82,4 +81,4 @@ module.exports = function(ID, data, options, db) {
 
   });
   return getInfo;
-}
+};

--- a/src/functions/subtract.js
+++ b/src/functions/subtract.js
@@ -11,7 +11,7 @@ module.exports = function(ID, data, options = {}, db) {
     options = {
       target: options.target || undefined,
       table: options.table || 'json'
-    }
+    };
 
     let response;
 

--- a/src/functions/subtract.js
+++ b/src/functions/subtract.js
@@ -2,13 +2,12 @@ const util = require('util'),
   _ = require('lodash/object');
 
 
-module.exports = function(ID, data, options, db) {
+module.exports = function(ID, data, options = {}, db) {
   const getInfo = new Promise((resolve, error) => {
 
-    if (typeof data !== 'number') return console.log('Error: .add() data is not a number.');
+    if (typeof data !== 'number') return error(new TypeError('.subtract() data is not a number.'));
 
     // Configure Options
-    if (!options) options = {};
     options = {
       target: options.target || undefined,
       table: options.table || 'json'
@@ -50,9 +49,9 @@ module.exports = function(ID, data, options, db) {
               input = JSON.stringify(input);
               db.prepare(`UPDATE ${options.table} SET json = (?) WHERE ID = (?)`).run(input, ID);
 
-            } else console.log(`Error: Target for .subtract(${ID}, ${data}) is not a number.`);
+            } else error(new TypeError(`Target for .subtract(${ID}, ${data}) is not a number.`));
 
-          } else console.log(`Error: Target for .subtract(${ID}, ${data}) is not a number.`);
+          } else error(new TypeError(`Target for .subtract(${ID}, ${data}) is not a number.`));
 
         }
 
@@ -79,4 +78,4 @@ module.exports = function(ID, data, options, db) {
 
   });
   return getInfo;
-}
+};

--- a/src/functions/tables.js
+++ b/src/functions/tables.js
@@ -1,5 +1,5 @@
 module.exports = function(db) {
-  const getInfo = new Promise((resolve, error) => {
+  const getInfo = new Promise(resolve => {
 
     let response = [];
     
@@ -11,8 +11,8 @@ module.exports = function(db) {
     function fetchAll() {
       let tables = db.prepare(`select name from sqlite_master where type='table'`).all();
       tables.forEach(function(table){
-        response.push(table.name) 
-      })
+        response.push(table.name);
+      });
       returnDb();
     }
 
@@ -24,4 +24,4 @@ module.exports = function(db) {
 
   });
   return getInfo;
-}
+};

--- a/src/queue.js
+++ b/src/queue.js
@@ -20,8 +20,8 @@ function executeQueue(object, queue) {
     default:
       if (!db) db = new Database('./json.sqlite');
       let realObj = object ? object : queue[0];
-      realObj.args.push(db)
-      realObj.args.push(webview)
+      realObj.args.push(db);
+      realObj.args.push(webview);
       tools[realObj.fun](...realObj.args).then((...result) => {
         realObj.innerFunc[0](...result);
         queue.shift();
@@ -114,8 +114,8 @@ var tools = module.exports = {
   table: function(name) { // This function deals with tables
 
     // Table Name Verification
-    if (typeof name !== 'string') return console.log('Sorry, please verify that name of the table is a string');
-    if (name.includes(' ')) return console.log('Sorry, the table name cannot include spaces');
+    if (typeof name !== 'string') return Promise.reject(new TypeError('Please verify that name of the table is a string'));
+    if (name.includes(' ')) return Promise.reject(new Error('Sorry, the table name cannot include spaces'));
     this.name = name; // Set Name
 
     // Parse Fetch
@@ -129,7 +129,7 @@ var tools = module.exports = {
           "innerFunc": [resolve, error]
         }, queue);
       });
-    }
+    };
 
     // Parse Set
     this.set = function(ID, data, options) {
@@ -142,7 +142,7 @@ var tools = module.exports = {
           "innerFunc": [resolve, error]
         }, queue);
       });
-    }
+    };
 
     // Parse Delete
     this.delete = function(ID, options) {
@@ -155,7 +155,7 @@ var tools = module.exports = {
           "innerFunc": [resolve, error]
         }, queue);
       });
-    }
+    };
 
     // Parse Push
     this.push = function(ID, data, options) {
@@ -168,7 +168,7 @@ var tools = module.exports = {
           "innerFunc": [resolve, error]
         }, queue);
       });
-    }
+    };
 
     // Parse Add
     this.add = function(ID, data, options) {
@@ -181,7 +181,7 @@ var tools = module.exports = {
           "innerFunc": [resolve, error]
         }, queue);
       });
-    }
+    };
 
     // Parse Subtract
     this.subtract = function(ID, data, options) {
@@ -194,7 +194,7 @@ var tools = module.exports = {
           "innerFunc": [resolve, error]
         }, queue);
       });
-    }
+    };
 
     // Parse FetchAll
     this.fetchAll = function(options) {
@@ -207,7 +207,7 @@ var tools = module.exports = {
           "innerFunc": [resolve, error]
         }, queue);
       });
-    }
+    };
 
     // Parse StartsWith
     this.startsWith = function(startsWith, options) {
@@ -219,10 +219,8 @@ var tools = module.exports = {
           "args": [startsWith, options],
           "innerFunc": [resolve, error]
         }, queue);
-
-      })
-
-    }
+      });
+    };
 
 
 

--- a/src/webviewer/createWebview.js
+++ b/src/webviewer/createWebview.js
@@ -25,31 +25,31 @@ module.exports = function(password, port, suburl) {
   if (!suburl) {
     app.get("/", function(request, response) {
       response.sendFile(__dirname + '/index.html')
-    })
+    });
 
     app.get("/data", function(request, response) {
       response.sendFile(__dirname + '/data.html')
-    })
+    });
   } else {
     // If suburl is a string
     if (typeof suburl === 'string') {
       app.get(`/${suburl}/`, function(request, response) {
         response.sendFile(__dirname + '/index.html')
-      })
+      });
 
       app.get(`/${suburl}/data`, function(request, response) {
         response.sendFile(__dirname + '/data.html')
-      })
+      });
     } else {
       // If it's not a string, convert suburl to a string
       let suburlString = String(suburl)
       app.get(`/${suburlString}/`, function(request, response) {
         response.sendFile(__dirname + '/index.html')
-      })
+      });
 
       app.get(`/${suburl}/data`, function(request, response) {
         response.sendFile(__dirname + '/data.html')
-      })
+      });
     };
   };
 
@@ -69,9 +69,9 @@ module.exports = function(password, port, suburl) {
         console.log(`Socket entered correct password: ${pass}`);
         socket.emit('respPassword', true);
         let db = new Database('./json.sqlite');
-        push(`WEBVIEW_ACTIVE_SOCKETS`, socket.id, undefined, db)
+        push(`WEBVIEW_ACTIVE_SOCKETS`, socket.id, undefined, db);
       }
-    })
+    });
 
     socket.on('requestData', function(tableName) {
       let db = new Database('./json.sqlite');
@@ -88,10 +88,10 @@ module.exports = function(password, port, suburl) {
             db.close();
           });
         });
-      })
-    })
+      });
+    });
 
-  })
+  });
 
 
-}
+};


### PR DESCRIPTION
Since quick.db is fully built with promises, any user mistakes will now reject with an error, so users can handle it (no errors will throw). User mistakes won’t be logged anymore.

Replaced a forEach with for of, simply because for of is faster. 

Added a default value {} for the options parameter in every method. Saves you 1 line in each file! :^)

Added semicolons to designate the files a little more. 